### PR TITLE
파일 업로드 안되는 이슈 트러블 슈팅

### DIFF
--- a/src/main/java/com/chatcode/config/WebConfig.java
+++ b/src/main/java/com/chatcode/config/WebConfig.java
@@ -1,15 +1,19 @@
 package com.chatcode.config;
 
 import com.chatcode.domain.file.Base64ToMultipartFileConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final Base64ToMultipartFileConverter base64ToMultipartFileConverter;
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new Base64ToMultipartFileConverter());
+        registry.addConverter(base64ToMultipartFileConverter);
     }
 }

--- a/src/main/java/com/chatcode/config/WebConfig.java
+++ b/src/main/java/com/chatcode/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.chatcode.config;
+
+import com.chatcode.domain.file.Base64ToMultipartFileConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new Base64ToMultipartFileConverter());
+    }
+}

--- a/src/main/java/com/chatcode/controller/FileController.java
+++ b/src/main/java/com/chatcode/controller/FileController.java
@@ -1,5 +1,6 @@
 package com.chatcode.controller;
 
+import com.chatcode.domain.file.ImageFile;
 import com.chatcode.dto.BaseResponseDto;
 import com.chatcode.dto.file.FileRequestDto;
 import com.chatcode.dto.file.FileResponseDto;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "파일 업로드 API", description = "파일 업로드 API")
 @RestController
@@ -28,8 +26,9 @@ public class FileController {
     @ApiResponse(responseCode = "200", description = "파일 업로드 성공")
     @ApiResponse(responseCode = "400", description = "빈 파일 업로드 시도")
     @ApiResponse(responseCode = "500", description = "파일 업로드 중 에러 발생")
-    public ResponseEntity<BaseResponseDto<FileResponseDto>> uploadFile(@ModelAttribute FileRequestDto dto) {
-        String imgPath = fileService.uploadImages(dto);
+    public ResponseEntity<BaseResponseDto<FileResponseDto>> uploadFile(@RequestBody FileRequestDto dto) {
+        ImageFile imageFile = new ImageFile(dto.getBase64File());
+        String imgPath = fileService.uploadImages(imageFile, dto.getTargetId());
 
         return ResponseEntity.ok(new BaseResponseDto<>(200, new FileResponseDto(imgPath), "success"));
     }

--- a/src/main/java/com/chatcode/domain/file/Base64ToMultipartFileConverter.java
+++ b/src/main/java/com/chatcode/domain/file/Base64ToMultipartFileConverter.java
@@ -1,0 +1,14 @@
+package com.chatcode.domain.file;
+
+import lombok.NonNull;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Base64ToMultipartFileConverter implements Converter<String, ImageFile> {
+
+    @Override
+    public ImageFile convert(@NonNull String source) {
+        return new ImageFile(source);
+    }
+}

--- a/src/main/java/com/chatcode/domain/file/DataUrl.java
+++ b/src/main/java/com/chatcode/domain/file/DataUrl.java
@@ -1,0 +1,49 @@
+package com.chatcode.domain.file;
+
+import com.chatcode.exception.file.EmptyImageFileException;
+import lombok.Getter;
+
+
+/**
+ * Data URLs 형태
+ * data:[<mediatype>][;base64],<data>
+ */
+@Getter
+public class DataUrl {
+    private final String metadata;
+    private final String base64Data;
+    private final String fileExtension;
+    private static final String IMAGE_MIMETYPE_PREFIX = "data:image/";
+
+    public DataUrl(String dataUrl) {
+        validateDataUrl(dataUrl);
+
+        String[] parts = dataUrl.split(",", 2);
+        this.metadata = parts[0];
+        this.base64Data = parts[1];
+        this.fileExtension = setFileExtension(parts[0]);
+    }
+
+    private static void validateDataUrl(String dataUrl) {
+        String[] parts = dataUrl.split(",", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid Data URL format");
+        }
+
+        if(parts[0].isBlank() || parts[1].isBlank()) {
+            throw new EmptyImageFileException();
+        }
+
+        if(!dataUrl.startsWith(IMAGE_MIMETYPE_PREFIX)){
+            throw new IllegalArgumentException("Not Image MIME Type");
+        }
+    }
+
+    private static String setFileExtension(String metadata) {
+        if (metadata.startsWith(IMAGE_MIMETYPE_PREFIX)) {
+            return metadata.substring(IMAGE_MIMETYPE_PREFIX.length(), metadata.indexOf(';'));
+        } {
+            throw new IllegalArgumentException("Unsupported image type");
+        }
+    }
+}

--- a/src/main/java/com/chatcode/dto/file/FileRequestDto.java
+++ b/src/main/java/com/chatcode/dto/file/FileRequestDto.java
@@ -2,13 +2,12 @@ package com.chatcode.dto.file;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
-import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @Schema
 public class FileRequestDto {
     @Schema(description = "이미지파일(base64형태)", example = "")
-    private MultipartFile base64File;
+    private String base64File;
     @Schema(description = "이미지가 업로드 될 게시글 번호", example = "1")
     private Long targetId;
 }

--- a/src/main/java/com/chatcode/service/FileService.java
+++ b/src/main/java/com/chatcode/service/FileService.java
@@ -19,10 +19,10 @@ public class FileService {
         fileRepository.save(fileDto.toEntity());
     }
 
-    public String uploadImages(final FileRequestDto dto) {
-        String imgPath = s3Service.uploadImage(new ImageFile(dto.getBase64File()));
+    public String uploadImages(ImageFile imageFile, Long targetId) {
+        String imgPath = s3Service.uploadImage(imageFile);
 
-        saveFile(FileDto.builder().url(imgPath).targetId(dto.getTargetId()).build());
+        saveFile(FileDto.builder().url(imgPath).targetId(targetId).build());
 
         return imgPath;
     }


### PR DESCRIPTION
## 🚀 Related Issues
> #28 
## 🛠️ Summary
> 파일 업로드 안되는 이슈 트러블 슈팅

### 💬 원인
base64인코딩 **String** -> **MultipartFile**타입 **converting을 Spring에서 지원해주지 않음**

### 💬 해결 방법
- Spring에서 제공하는 Convert기능 활용하여 [참고](https://jddng.tistory.com/290)
base64인코딩 String -> MultipartFile Converting을 하였습니다.

- ImageFile클래스를 MutlipartFile 구현체로 활용 
 -> MultipartFile은 인터페이스이기 때문에, 내부적으로 MultipartFile 타입의 인스턴스를 생성하기 위해서 구현체가 필요
