### PR TITLE
refactor(interestTag): DELETE method request body 삭제

### DIFF
--- a/src/main/java/com/chatcode/controller/InterestTagController.java
+++ b/src/main/java/com/chatcode/controller/InterestTagController.java
@@ -52,20 +52,20 @@ public class InterestTagController {
     @PostMapping("/avatars/interest-tags")
     @Operation(summary = "USER의 관심 태그 추가", description = "USER의 관심 태그를 추가합니다. (본인만 접근 가능)")
     @ApiResponse(responseCode = "201", description = "USER의 관심 태그 추가 성공")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<BaseResponseDto<InterestTagResponse>> addUserTag(@RequestBody List<InterestTagIdRequest> params,
                                                                     @AuthenticationPrincipal LoginUser loginUser) {
         avatarService.addInterestTags(params, loginUser.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponseDto<>(HttpStatus.CREATED.value(), null, "success"));
     }
 
-    @DeleteMapping("/avatars/interest-tags")
+    @DeleteMapping("/avatars/interest-tags/{interestTagId}")
     @Operation(summary = "USER의 관심 태그 삭제", description = "USER의 관심 태그를 삭제합니다. (본인만 접근 가능)")
-    @ApiResponse(responseCode = "204", description = "USER의 관심 태그 삭제 성공")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<BaseResponseDto<InterestTagResponse>> delete(@RequestBody List<InterestTagIdRequest> params,
+    @ApiResponse(responseCode = "200", description = "USER의 관심 태그 삭제 성공")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<BaseResponseDto<InterestTagResponse>> delete(@PathVariable Long interestTagId,
                                                                        @AuthenticationPrincipal LoginUser loginUser) {
-        avatarService.deleteInterestTags(params, loginUser.getId());
+        avatarService.deleteInterestTags(interestTagId, loginUser.getId());
         return ResponseEntity.status(HttpStatus.OK).body(new BaseResponseDto<>(HttpStatus.OK.value(), null, "success"));
     }
 
@@ -77,11 +77,11 @@ public class InterestTagController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponseDto<>(HttpStatus.CREATED.value(), responseBody, "success"));
     }
 
-    @DeleteMapping("/admin/interest-tags")
+    @DeleteMapping("/admin/interest-tags/{interestTagId}")
     @Operation(summary = "관심 태그 삭제", description = "관심 태그를 삭제합니다. (관리자만 접근 가능)")
-    @ApiResponse(responseCode = "204", description = "관심 태그 삭제 성공")
-    public ResponseEntity<BaseResponseDto<InterestTagResponse>> delete(@RequestBody List<InterestTagIdRequest> params) {
-        interestTagService.deleteInterestTags(params);
+    @ApiResponse(responseCode = "200", description = "관심 태그 삭제 성공")
+    public ResponseEntity<BaseResponseDto<Void>> delete(@PathVariable Long interestTagId) {
+        interestTagService.deleteInterestTags(interestTagId);
         return ResponseEntity.status(HttpStatus.OK).body(new BaseResponseDto<>(HttpStatus.OK.value(), null, "success"));
     }
 

--- a/src/main/java/com/chatcode/service/AvatarService.java
+++ b/src/main/java/com/chatcode/service/AvatarService.java
@@ -1,6 +1,7 @@
 package com.chatcode.service;
 
 import com.chatcode.domain.entity.Avatar;
+import com.chatcode.domain.entity.InterestTag;
 import com.chatcode.dto.avatar.AvatarRequest.AvatarCreateRequest;
 import com.chatcode.dto.avatar.AvatarRequest.AvatarUpdateRequest;
 import com.chatcode.dto.avatar.AvatarResponse;
@@ -90,15 +91,12 @@ public class AvatarService {
     }
 
     @Transactional
-    public void deleteInterestTags(List<InterestTagIdRequest> params, Long id) {
+    public void deleteInterestTags(Long interestTagId, Long id) {
         Avatar avatar = avatarReadRepository.findById(id)
                 .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
 
-        params.stream()
-                .map(InterestTagIdRequest::getId)
-                .map(interestTagWriteRepository::getReferenceById)
-                .forEach(avatar::removeInterestTag);
-        avatarWriteRepository.save(avatar);
+        InterestTag interestTag = interestTagWriteRepository.getReferenceById(interestTagId);
+        avatar.removeInterestTag(interestTag);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/chatcode/service/InterestTagService.java
+++ b/src/main/java/com/chatcode/service/InterestTagService.java
@@ -1,7 +1,6 @@
 package com.chatcode.service;
 
 import com.chatcode.domain.entity.InterestTag;
-import com.chatcode.dto.tag.InterestTagRequest.InterestTagIdRequest;
 import com.chatcode.dto.tag.InterestTagRequest.InterestTagNameRequest;
 import com.chatcode.dto.tag.InterestTagRequest.InterestTagRenameRequest;
 import com.chatcode.dto.tag.InterestTagResponse;
@@ -39,11 +38,8 @@ public class InterestTagService {
     }
 
     @Transactional
-    public void deleteInterestTags(List<InterestTagIdRequest> params) {
-        List<InterestTag> tags = params.stream()
-                        .map(tag -> interestTagWriteRepository.getReferenceById(tag.getId()))
-                        .toList();
-        interestTagWriteRepository.deleteAll(tags);
+    public void deleteInterestTags(Long params) {
+        interestTagWriteRepository.deleteById(params);
     }
 
     @Transactional


### PR DESCRIPTION
## 🚀 Related Issues
> #41
## 🛠️ Summary
> https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
> DELETE method에서는 request body를 사용하지 않는 것이 권장된다고 합니다.
> 따라서, 사용할 객체의 ID를 PathParameter 를 통해 입력 받고 해당 tag를 삭제할 수 있도록 수정하였습니다.
## 💬 Review Requirements
>
