### PR TITLE
feat(error code): error code 등록 및 custom exception 리펙토링

### DIFF
--- a/src/main/java/com/chatcode/exception/ExceptionCode.java
+++ b/src/main/java/com/chatcode/exception/ExceptionCode.java
@@ -1,0 +1,34 @@
+package com.chatcode.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
+
+    NOT_FOUND_ARTICLE_ID(1001, "요청한 ID에 해당하는 게시글이 존재하지 않습니다."),
+    NOT_FOUND_CONTENT_ID(1002, "요청한 ID에 해당하는 컨텐츠가 존재하지 않습니다."),
+    NOT_FOUND_AVATAR_ID(1003, "요청한 ID에 해당하는 아바타가 존재하지 않습니다."),
+    NOT_FOUND_CATEGORY_ID(1004, "요청한 ID에 해당하는 카테고리가 존재하지 않습니다."),
+    NOT_FOUND_SCRAP_ID(1005, "요청한 ID에 해당하는 스크랩이 존재하지 않습니다."),
+    NOT_FOUND_TAG_ID(1006, "요청한 ID에 해당하는 태그가 존재하지 않습니다."),
+    NOT_FOUND_RESOURCE_ID(1007, "요청한 ID에 해당하는 리소스가 존재하지 않습니다."),
+    NOT_FOUND_CONTENT_FROM_ARTICLE_ID(1008, "요청한 아티클에 해당하는 컨탠츠가이 존재하지 않습니다."),
+
+    INVALID_CATEGORY_ORDER_SIZE(2001, "요청한 카테고리에 누락된 ID가 존재합니다."),
+    INVALID_CATEGORY_ORDER_DUPLICATE(2002, "요청한 카테고리에 중복된 ID가 존재합니다."),
+
+    INVALID_IMAGE_URL(3001, "요청한 이미지 URL의 형식이 잘못되었습니다."),
+    FAIL_IMAGE_UPLOAD(3002, "이미지 파일 업로드 중 에러가 발생했습니다."),
+    EMPTY_IMAGE_FILE(3003, "이미지 파일이 비어있습니다."),
+
+    ALREADY_REACTED(4001, "해당 컨텐츠에 대해서 이미 반응을 하였습니다."),
+
+    INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/chatcode/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chatcode/exception/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package com.chatcode.exception;
 
+import static com.chatcode.exception.ExceptionCode.INTERNAL_SEVER_ERROR;
+
 import com.chatcode.dto.BaseResponseDto;
-import com.chatcode.exception.common.ContentNotFoundException;
-import com.chatcode.exception.common.ResourceNotFoundException;
-import com.chatcode.exception.file.EmptyImageFileException;
-import com.chatcode.exception.file.ImageFileUploadException;
-import com.chatcode.exception.reaction.AlreadyReactException;
-import org.springframework.http.HttpStatus;
+import com.chatcode.exception.category.CategoryException;
+import com.chatcode.exception.common.NotFoundException;
+import com.chatcode.exception.file.ImageException;
+import com.chatcode.exception.reaction.ReactException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,34 +14,29 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(AlreadyReactException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleAlreadyReactException(AlreadyReactException ex) {
-        //Todo 에러 코드 정하기
-        return ResponseEntity.badRequest().body(new BaseResponseDto<>(HttpStatus.BAD_REQUEST.value(), null ,ex.getMessage()));
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<BaseResponseDto<Object>> handleNotFoundException(NotFoundException ex) {
+        return ResponseEntity.badRequest().body(new BaseResponseDto<>(ex.getCode(), ex.getData(), ex.getMessage()));
     }
 
-    @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        return ResponseEntity.badRequest().body(new BaseResponseDto<>(HttpStatus.BAD_REQUEST.value(), null ,ex.getMessage()));
+    @ExceptionHandler(ReactException.class)
+    public ResponseEntity<BaseResponseDto<Object>> handleAlreadyReactException(ReactException ex) {
+        return ResponseEntity.badRequest().body(new BaseResponseDto<>(ex.getCode(), ex.getData(), ex.getMessage()));
     }
 
-    @ExceptionHandler(EmptyImageFileException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleEmptyImageFileException(EmptyImageFileException ex) {
-        return ResponseEntity.badRequest().body(new BaseResponseDto<>(HttpStatus.BAD_REQUEST.value(), null ,ex.getMessage()));
-    }
-    @ExceptionHandler(ImageFileUploadException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleImageFileUploadException(ImageFileUploadException ex) {
-        return ResponseEntity.badRequest().body(new BaseResponseDto<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), null ,ex.getMessage()));
+    @ExceptionHandler(ImageException.class)
+    public ResponseEntity<BaseResponseDto<Object>> handleImageException(ImageException ex) {
+        return ResponseEntity.badRequest().body(new BaseResponseDto<>(ex.getCode(), ex.getData(), ex.getMessage()));
     }
 
-    @ExceptionHandler(ContentNotFoundException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleContentNotFoundException(ContentNotFoundException ex) {
-        return ResponseEntity.badRequest().body(new BaseResponseDto<>(HttpStatus.BAD_REQUEST.value(), null, ex.getMessage()));
+    @ExceptionHandler(CategoryException.class)
+    public ResponseEntity<BaseResponseDto<Object>> handleCategoryException(CategoryException ex) {
+        return ResponseEntity.badRequest().body(new BaseResponseDto<>(ex.getCode(), ex.getData(), ex.getMessage()));
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<BaseResponseDto<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleException(Exception ex) {
         return ResponseEntity.badRequest()
-                .body(new BaseResponseDto<>(HttpStatus.BAD_REQUEST.value(), null, ex.getMessage()));
+                .body(new BaseResponseDto<>(INTERNAL_SEVER_ERROR.getCode(), null, INTERNAL_SEVER_ERROR.getMessage()));
     }
 }

--- a/src/main/java/com/chatcode/exception/category/CategoryException.java
+++ b/src/main/java/com/chatcode/exception/category/CategoryException.java
@@ -1,0 +1,23 @@
+package com.chatcode.exception.category;
+
+import com.chatcode.exception.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class CategoryException extends RuntimeException {
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public CategoryException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = null;
+    }
+
+    public CategoryException(final ExceptionCode exceptionCode, Object data) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/com/chatcode/exception/category/CategoryOrderException.java
+++ b/src/main/java/com/chatcode/exception/category/CategoryOrderException.java
@@ -1,0 +1,13 @@
+package com.chatcode.exception.category;
+
+import com.chatcode.exception.ExceptionCode;
+
+public class CategoryOrderException extends CategoryException {
+    public CategoryOrderException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+
+    public CategoryOrderException(ExceptionCode exceptionCode, Object data) {
+        super(exceptionCode, data);
+    }
+}

--- a/src/main/java/com/chatcode/exception/category/IllegalCategoryOrderException.java
+++ b/src/main/java/com/chatcode/exception/category/IllegalCategoryOrderException.java
@@ -1,7 +1,0 @@
-package com.chatcode.exception.category;
-
-public class IllegalCategoryOrderException extends IllegalArgumentException {
-    public IllegalCategoryOrderException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/chatcode/exception/common/ContentNotFoundException.java
+++ b/src/main/java/com/chatcode/exception/common/ContentNotFoundException.java
@@ -1,8 +1,13 @@
 package com.chatcode.exception.common;
 
- public class ContentNotFoundException extends RuntimeException {
-        public ContentNotFoundException(String message) {
-            super(message);
-        }
+import com.chatcode.exception.ExceptionCode;
 
+public class ContentNotFoundException extends NotFoundException {
+    public ContentNotFoundException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+
+    public ContentNotFoundException(ExceptionCode exceptionCode, Object data) {
+        super(exceptionCode, data);
+    }
 }

--- a/src/main/java/com/chatcode/exception/common/NotFoundException.java
+++ b/src/main/java/com/chatcode/exception/common/NotFoundException.java
@@ -1,0 +1,23 @@
+package com.chatcode.exception.common;
+
+import com.chatcode.exception.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public NotFoundException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = null;
+    }
+
+    public NotFoundException(final ExceptionCode exceptionCode, Object data) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/com/chatcode/exception/common/ResourceNotFoundException.java
+++ b/src/main/java/com/chatcode/exception/common/ResourceNotFoundException.java
@@ -1,11 +1,13 @@
 package com.chatcode.exception.common;
 
-public class ResourceNotFoundException extends RuntimeException {
-  public ResourceNotFoundException() {
-    super("Resource is not found");
-  }
+import com.chatcode.exception.ExceptionCode;
 
-  public ResourceNotFoundException(String message) {
-    super(message);
-  }
+public class ResourceNotFoundException extends NotFoundException {
+    public ResourceNotFoundException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+
+    public ResourceNotFoundException(ExceptionCode exceptionCode, Object data) {
+        super(exceptionCode, data);
+    }
 }

--- a/src/main/java/com/chatcode/exception/file/EmptyImageFileException.java
+++ b/src/main/java/com/chatcode/exception/file/EmptyImageFileException.java
@@ -1,11 +1,9 @@
 package com.chatcode.exception.file;
 
-public class EmptyImageFileException extends RuntimeException{
-    public EmptyImageFileException(){
-        super("이미지 파일이 존재하지 않습니다.");
-    }
+import static com.chatcode.exception.ExceptionCode.EMPTY_IMAGE_FILE;
 
-    public EmptyImageFileException(String message){
-        super(message);
+public class EmptyImageFileException extends ImageException {
+    public EmptyImageFileException() {
+        super(EMPTY_IMAGE_FILE);
     }
 }

--- a/src/main/java/com/chatcode/exception/file/ImageException.java
+++ b/src/main/java/com/chatcode/exception/file/ImageException.java
@@ -1,0 +1,23 @@
+package com.chatcode.exception.file;
+
+import com.chatcode.exception.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class ImageException extends RuntimeException {
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public ImageException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = null;
+    }
+
+    public ImageException(final ExceptionCode exceptionCode, Object data) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/com/chatcode/exception/file/ImageFileUploadException.java
+++ b/src/main/java/com/chatcode/exception/file/ImageFileUploadException.java
@@ -1,11 +1,13 @@
 package com.chatcode.exception.file;
 
-public class ImageFileUploadException extends RuntimeException{
-    public ImageFileUploadException(){
-        super("이미지 파일 업로드 중 에러가 발생했습니다.");
+import static com.chatcode.exception.ExceptionCode.FAIL_IMAGE_UPLOAD;
+
+public class ImageFileUploadException extends ImageException {
+    public ImageFileUploadException() {
+        super(FAIL_IMAGE_UPLOAD);
     }
 
-    public ImageFileUploadException(String message){
-        super(message);
+    public ImageFileUploadException(String message) {
+        super(FAIL_IMAGE_UPLOAD, message);
     }
 }

--- a/src/main/java/com/chatcode/exception/reaction/AlreadyReactException.java
+++ b/src/main/java/com/chatcode/exception/reaction/AlreadyReactException.java
@@ -1,11 +1,14 @@
 package com.chatcode.exception.reaction;
 
-public class AlreadyReactException extends RuntimeException{
-  public AlreadyReactException(){
-    super("You have already raected to this content.");
-  }
+import static com.chatcode.exception.ExceptionCode.ALREADY_REACTED;
 
-  public AlreadyReactException(String message){
-    super(message);
-  }
+
+public class AlreadyReactException extends ReactException {
+    public AlreadyReactException() {
+        super(ALREADY_REACTED);
+    }
+
+    public AlreadyReactException(String message) {
+        super(ALREADY_REACTED, message);
+    }
 }

--- a/src/main/java/com/chatcode/exception/reaction/ReactException.java
+++ b/src/main/java/com/chatcode/exception/reaction/ReactException.java
@@ -1,0 +1,23 @@
+package com.chatcode.exception.reaction;
+
+import com.chatcode.exception.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class ReactException extends RuntimeException {
+    private final int code;
+    private final String message;
+    private final Object data;
+
+    public ReactException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = null;
+    }
+
+    public ReactException(final ExceptionCode exceptionCode, Object data) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/com/chatcode/repository/ArticleRepository.java
+++ b/src/main/java/com/chatcode/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.chatcode.repository;
 
 import com.chatcode.dto.article.ArticleRequestDTO.ArticleCreateRequestDTO;
 import com.chatcode.dto.article.ArticleRequestDTO.ArticleUpdateRequestDTO;
+import com.chatcode.exception.ExceptionCode;
 import com.chatcode.exception.common.ContentNotFoundException;
 import com.chatcode.jooq.tables.Article;
 import com.chatcode.jooq.tables.Content;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_CONTENT_FROM_ARTICLE_ID;
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_CONTENT_ID;
 import static com.chatcode.jooq.Tables.ARTICLE;
 import static com.chatcode.jooq.Tables.CONTENT;
 import static org.jooq.impl.DSL.currentLocalDateTime;
@@ -57,7 +60,7 @@ public class ArticleRepository {
                 .fetchOneInto(Long.class);
 
         if (contentId == null) {
-            throw new ContentNotFoundException("Content not found for article id: " + articleId);
+            throw new ContentNotFoundException(NOT_FOUND_CONTENT_FROM_ARTICLE_ID, articleId);
         }
         return contentId;
     }

--- a/src/main/java/com/chatcode/service/ArticleService.java
+++ b/src/main/java/com/chatcode/service/ArticleService.java
@@ -1,11 +1,14 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_CONTENT_FROM_ARTICLE_ID;
+
 import com.chatcode.domain.common.PageInfo;
 import com.chatcode.dto.BaseResponseDto;
 import com.chatcode.dto.article.ArticleRequestDTO.ArticleCreateRequestDTO;
 import com.chatcode.dto.article.ArticleRequestDTO.ArticleUpdateRequestDTO;
 import com.chatcode.dto.article.ArticleResponseDTO;
 import com.chatcode.dto.article.ArticleRetrieveServiceDto;
+import com.chatcode.exception.ExceptionCode;
 import com.chatcode.exception.common.ContentNotFoundException;
 import com.chatcode.repository.ArticleRepository;
 import com.chatcode.repository.article.ArticleReadRepository;
@@ -32,7 +35,7 @@ public class ArticleService {
         // 아티클 아이디에 매핑된 콘텐츠 아이디 조회
         Long contentId = articleRepository.findContentIdByArticleId(articleId);
         if (contentId == null) {
-            throw new ContentNotFoundException("해당 아티클에 대한 콘텐츠가 없습니다.");
+            throw new ContentNotFoundException(NOT_FOUND_CONTENT_FROM_ARTICLE_ID, articleId);
         }
         articleRepository.updateArticle(articleId, contentId, updateDTO);
     }

--- a/src/main/java/com/chatcode/service/AvatarService.java
+++ b/src/main/java/com/chatcode/service/AvatarService.java
@@ -1,5 +1,7 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_AVATAR_ID;
+
 import com.chatcode.domain.entity.Avatar;
 import com.chatcode.domain.entity.InterestTag;
 import com.chatcode.dto.avatar.AvatarRequest.AvatarCreateRequest;
@@ -7,6 +9,7 @@ import com.chatcode.dto.avatar.AvatarRequest.AvatarUpdateRequest;
 import com.chatcode.dto.avatar.AvatarResponse;
 import com.chatcode.dto.tag.InterestTagRequest.InterestTagIdRequest;
 import com.chatcode.dto.tag.InterestTagResponse;
+import com.chatcode.exception.ExceptionCode;
 import com.chatcode.exception.common.ContentNotFoundException;
 import com.chatcode.repository.avatar.AvatarReadRepository;
 import com.chatcode.repository.avatar.AvatarWriteRepository;
@@ -41,7 +44,7 @@ public class AvatarService {
     @Transactional
     public AvatarResponse updateAvatar(Long avatarId, AvatarUpdateRequest params) {
         Avatar avatar = avatarReadRepository.findById(avatarId)
-                .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
+                .orElseThrow(() -> new ContentNotFoundException(NOT_FOUND_AVATAR_ID));
 
         if (params.getNickname() != null) {
             avatar.setNickname(params.getNickname());
@@ -63,7 +66,7 @@ public class AvatarService {
             Avatar avatar = avatarWriteRepository.getReferenceById(id);
             avatarWriteRepository.delete(avatar);
         } catch (EntityNotFoundException e) {
-            throw new ContentNotFoundException("Avatar not found");
+            throw new ContentNotFoundException(NOT_FOUND_AVATAR_ID);
         }
     }
 
@@ -77,14 +80,14 @@ public class AvatarService {
     @Transactional(readOnly = true)
     public AvatarResponse getOneAvatar(Long id) {
         Avatar avatar = avatarReadRepository.findById(id)
-                .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
+                .orElseThrow(() -> new ContentNotFoundException(NOT_FOUND_AVATAR_ID));
         return AvatarResponse.of(avatar);
     }
 
     @Transactional
     public void addInterestTags(List<InterestTagIdRequest> params, Long id) {
         Avatar avatar = avatarReadRepository.findById(id)
-                .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
+                .orElseThrow(() -> new ContentNotFoundException(NOT_FOUND_AVATAR_ID));
 
         params.stream()
                 .map(InterestTagIdRequest::getId)
@@ -96,7 +99,7 @@ public class AvatarService {
     @Transactional
     public void deleteInterestTags(Long interestTagId, Long id) {
         Avatar avatar = avatarReadRepository.findById(id)
-                .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
+                .orElseThrow(() -> new ContentNotFoundException(NOT_FOUND_AVATAR_ID));
 
         InterestTag interestTag = interestTagWriteRepository.getReferenceById(interestTagId);
         avatar.removeInterestTag(interestTag);
@@ -105,7 +108,7 @@ public class AvatarService {
     @Transactional(readOnly = true)
     public List<InterestTagResponse> getInterestTags(Long avatarId) {
         Avatar avatar = avatarReadRepository.findById(avatarId)
-                .orElseThrow(() -> new ContentNotFoundException("Avatar not found"));
+                .orElseThrow(() -> new ContentNotFoundException(NOT_FOUND_AVATAR_ID));
 
         return avatar.getAvatarInterestTags().stream()
                 .map(avatarInterestTag -> InterestTagResponse.of(avatarInterestTag.getInterestTag()))

--- a/src/main/java/com/chatcode/service/FollowService.java
+++ b/src/main/java/com/chatcode/service/FollowService.java
@@ -1,9 +1,12 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_AVATAR_ID;
+
 import com.chatcode.domain.entity.Avatar;
 import com.chatcode.domain.entity.Follow;
 import com.chatcode.dto.avatar.AvatarResponse;
 import com.chatcode.exception.common.ContentNotFoundException;
+import com.chatcode.exception.common.ResourceNotFoundException;
 import com.chatcode.repository.avatar.AvatarWriteRepository;
 import com.chatcode.repository.follow.FollowReadRepository;
 import com.chatcode.repository.follow.FollowWriteRepository;
@@ -28,7 +31,7 @@ public class FollowService {
             Avatar following = avatarWriteRepository.getReferenceById(followingId);
             followWriteRepository.save(Follow.of(follower, following));
         } catch (EntityNotFoundException e) {
-            throw new ContentNotFoundException("Follow: Avatar not found");
+            throw new ResourceNotFoundException(NOT_FOUND_AVATAR_ID);
         }
     }
 

--- a/src/main/java/com/chatcode/service/InterestTagService.java
+++ b/src/main/java/com/chatcode/service/InterestTagService.java
@@ -1,10 +1,13 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_TAG_ID;
+
 import com.chatcode.domain.entity.InterestTag;
 import com.chatcode.dto.tag.InterestTagRequest.InterestTagNameRequest;
 import com.chatcode.dto.tag.InterestTagRequest.InterestTagRenameRequest;
 import com.chatcode.dto.tag.InterestTagResponse;
 import com.chatcode.exception.common.ContentNotFoundException;
+import com.chatcode.exception.common.ResourceNotFoundException;
 import com.chatcode.repository.tag.InterestTagReadRepository;
 import com.chatcode.repository.tag.InterestTagWriteRepository;
 import java.util.List;
@@ -47,7 +50,7 @@ public class InterestTagService {
         List<InterestTag> tags = params.stream()
                         .map(tag -> {
                             InterestTag entity = interestTagReadRepository.findById(tag.getId())
-                                    .orElseThrow(() -> new ContentNotFoundException("Interest tag not found"));
+                                    .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_TAG_ID));
                             entity.setName(tag.getName());
                             return entity;
                         })

--- a/src/main/java/com/chatcode/service/LikeService.java
+++ b/src/main/java/com/chatcode/service/LikeService.java
@@ -1,10 +1,13 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_RESOURCE_ID;
+
 import com.chatcode.domain.LikeableContentType;
 import com.chatcode.domain.entity.Article;
 import com.chatcode.domain.entity.Opinion;
 import com.chatcode.dto.like.LikeRequest;
 import com.chatcode.dto.like.Likeable;
+import com.chatcode.exception.ExceptionCode;
 import com.chatcode.exception.common.ResourceNotFoundException;
 import com.chatcode.exception.reaction.AlreadyReactException;
 import com.chatcode.repository.ReadRepository;
@@ -44,7 +47,7 @@ public class LikeService {
   private <T extends Likeable> T fetchContent(ReadRepository<T> repository, int contentId,
       String typeName) {
     return repository.findById(contentId).orElseThrow(() ->
-        new ResourceNotFoundException(typeName + " not found with ID: " + contentId));
+            new ResourceNotFoundException(NOT_FOUND_RESOURCE_ID, "type" + typeName + ", ID" + contentId));
   }
 
   private void updateLikeCount(LikeableContentType contentType, Likeable content,

--- a/src/main/java/com/chatcode/service/ScrapService.java
+++ b/src/main/java/com/chatcode/service/ScrapService.java
@@ -1,9 +1,12 @@
 package com.chatcode.service;
 
+import static com.chatcode.exception.ExceptionCode.NOT_FOUND_SCRAP_ID;
+
 import com.chatcode.domain.entity.Article;
 import com.chatcode.domain.entity.Avatar;
 import com.chatcode.domain.entity.Scrap;
 import com.chatcode.dto.ScrapResponseDto;
+import com.chatcode.exception.ExceptionCode;
 import com.chatcode.exception.common.ContentNotFoundException;
 import com.chatcode.repository.article.ArticleWriteRepository;
 import com.chatcode.repository.avatar.AvatarWriteRepository;
@@ -49,6 +52,6 @@ public class ScrapService {
             scrapWriteRepository.delete(scrap.get());
             return;
         }
-        throw new ContentNotFoundException("Scrap not found");
+        throw new ContentNotFoundException(NOT_FOUND_SCRAP_ID);
     }
 }


### PR DESCRIPTION
## 🚀 Related Issues
> Resolve #32
## 🛠️ Summary
> - Error code 정의
> - Custom Exception 클래스 구조 수정
>    - 기존: String 으로 exception message 전달
>    - 수정: Error code로 exception message 전달
> - GlobalExceptionHandler 수정
>    - 기존: 각각의 exception handling
>    - 수정: 상속으로 범주화된 exception 마다 handling
## 💬 Review Requirements
> 리펙토링을 해보긴 했는데, 민제님이 의도하신 대로 제가 잘 구현했는지 잘 모르겠네요😂. 

> hang-log 프로젝트 참고해서 exception을 핸들링 처리했는데, 사실 상위 exception 클래스(NotFoundException, ReactException, ImageException, CategoryException)의 구조가 모두 동일해서 하나로(예를들어 BaseException) 묶는 건 어떨지 고민도 됐습니다.
