### PR TITLE
Feature/#68 article category

### DIFF
--- a/db/mysql/initdb.d/create_table.sql
+++ b/db/mysql/initdb.d/create_table.sql
@@ -40,7 +40,7 @@ CREATE TABLE `article`
     `view_count`       int(11) NOT NULL,
     `like_count`       int(11) NOT NULL,
     `dislike_count`    int(11) NOT NULL,
-    `category_id`      varchar(255) NOT NULL,
+    `category_id`      bigint(20) NULL,
     CONSTRAINT PK_ARTICLE PRIMARY KEY (`id`)
 );
 

--- a/src/main/java/com/chatcode/config/dummy/DummyDevInit.java
+++ b/src/main/java/com/chatcode/config/dummy/DummyDevInit.java
@@ -5,6 +5,8 @@ import com.chatcode.domain.entity.*;
 import com.chatcode.repository.article.ArticleWriteRepository;
 import com.chatcode.repository.avatar.AvatarReadRepository;
 import com.chatcode.repository.avatar.AvatarWriteRepository;
+import com.chatcode.repository.category.CategoryReadRepository;
+import com.chatcode.repository.category.CategoryWriteRepository;
 import com.chatcode.repository.content.ContentWriteRepository;
 import com.chatcode.repository.role.RoleReadRepository;
 import com.chatcode.repository.role.RoleWriteRepository;
@@ -28,6 +30,7 @@ public class DummyDevInit extends DummyObject {
     private final EntityManager em;
 
     private static final Faker faker = new Faker();
+    private static int categorySortOrder = 1;
 
     @Bean
     CommandLineRunner dummyUsers(
@@ -103,6 +106,30 @@ public class DummyDevInit extends DummyObject {
             });
             em.clear();
         });
+    }
+
+    @Bean
+    CommandLineRunner dummyCategories(CategoryWriteRepository categoryWriteRepository,
+                                      CategoryReadRepository categoryReadRepository) {
+        return (args -> {
+            List<Category> categories = List.of(
+                    newCategory("Free"),
+                    newCategory("Question")
+            );
+            categories.forEach(category -> {
+                categoryReadRepository.findByName(category.getName())
+                        .orElseGet(() -> categoryWriteRepository.save(category));
+            });
+            em.clear();
+        });
+    }
+
+
+    private Category newCategory(String community) {
+        return new Category().builder()
+                .name(community)
+                .sortOrder(categorySortOrder++)
+                .build();
     }
 
 

--- a/src/main/java/com/chatcode/config/dummy/DummyDevInit.java
+++ b/src/main/java/com/chatcode/config/dummy/DummyDevInit.java
@@ -179,7 +179,7 @@ public class DummyDevInit extends DummyObject {
                 .viewCount(faker.random().nextInt())
                 .likeCount(faker.random().nextInt())
                 .dislikeCount(faker.random().nextInt())
-                .categoryId("question")
+                .categoryId(faker.random().nextLong(1, 2))
                 .build();
     }
 

--- a/src/main/java/com/chatcode/controller/ArticleController.java
+++ b/src/main/java/com/chatcode/controller/ArticleController.java
@@ -68,7 +68,7 @@ public class ArticleController {
         return ResponseEntity.ok(new BaseResponseDto<>(1, null, "업데이트 성공"));
     }
 
-    @GetMapping("")
+    @PostMapping("/list")
     @Operation(summary = "Article 목록 조회", description = "Article 목록을 조회합니다.")
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/chatcode/domain/entity/Article.java
+++ b/src/main/java/com/chatcode/domain/entity/Article.java
@@ -64,7 +64,7 @@ public class Article extends AuditingFields implements Likeable {
   private Integer dislikeCount;
 
   @Column(name = "category_id", nullable = false)
-  private String categoryId;
+  private Long categoryId;
 
   public void updateLikeCount(LikeRequest likeRequest) {
     if (likeRequest.getIsLike()) {

--- a/src/main/java/com/chatcode/domain/entity/Category.java
+++ b/src/main/java/com/chatcode/domain/entity/Category.java
@@ -6,9 +6,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Entity

--- a/src/main/java/com/chatcode/dto/article/ArticleRequestDTO.java
+++ b/src/main/java/com/chatcode/dto/article/ArticleRequestDTO.java
@@ -28,7 +28,6 @@ public class ArticleRequestDTO {
 
         // category
         @NotNull(message = "카테고리를 선택해주세요.")
-        @NotEmpty(message = "카테고리를 선택해주세요.")
         private Long categoryId;
     }
 

--- a/src/main/java/com/chatcode/dto/article/ArticleRequestDTO.java
+++ b/src/main/java/com/chatcode/dto/article/ArticleRequestDTO.java
@@ -25,6 +25,11 @@ public class ArticleRequestDTO {
 
         // tags
         private List<String> tags;
+
+        // category
+        @NotNull(message = "카테고리를 선택해주세요.")
+        @NotEmpty(message = "카테고리를 선택해주세요.")
+        private Long categoryId;
     }
 
     @Data
@@ -44,5 +49,10 @@ public class ArticleRequestDTO {
 
         // tags
         private List<String> tags;
+
+        // category
+        @NotNull(message = "카테고리를 선택해주세요.")
+        @NotEmpty(message = "카테고리를 선택해주세요.")
+        private Long categoryId;
     }
 }

--- a/src/main/java/com/chatcode/handler/exception/ExceptionCode.java
+++ b/src/main/java/com/chatcode/handler/exception/ExceptionCode.java
@@ -17,6 +17,7 @@ public enum ExceptionCode {
     NOT_FOUND_TAG_ID(1006, "요청한 ID에 해당하는 태그가 존재하지 않습니다."),
     NOT_FOUND_RESOURCE_ID(1007, "요청한 ID에 해당하는 리소스가 존재하지 않습니다."),
     NOT_FOUND_CONTENT_FROM_ARTICLE_ID(1008, "요청한 아티클에 해당하는 컨탠츠가이 존재하지 않습니다."),
+    NOT_FOUND_CATEGORY_NAME(1009, "요청한 카테고리 이름은 존재하지 않습니다."),
 
     INVALID_CATEGORY_ORDER_SIZE(2001, "요청한 카테고리에 누락된 ID가 존재합니다."),
     INVALID_CATEGORY_ORDER_DUPLICATE(2002, "요청한 카테고리에 중복된 ID가 존재합니다."),

--- a/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
+++ b/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
@@ -98,7 +98,8 @@ public class ArticleReadRepository implements ReadRepository<Article> {
         }
 
         if (request.getCategory() != null) {
-            result = result.and(ARTICLE.CATEGORY_ID.eq(request.getCategory().name()));
+            // TODO: Fix this (request.getCategory().name() 가 category 이름이라면? 어떻게 비교?)
+//            result = result.and(ARTICLE.CATEGORY_ID.eq(request.getCategory().name()));
         }
 
         return result;

--- a/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
+++ b/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
@@ -93,9 +93,6 @@ public class ArticleReadRepository implements ReadRepository<Article> {
 
     public Condition condition(ArticleRetrieveServiceDto request) {
 
-        Category requestCategory = categoryReadRepository.findByName(request.getCategory().name())
-                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_CATEGORY_NAME));
-
         Condition result = noCondition();
 
         if (request.getSearch() != null) {
@@ -107,6 +104,8 @@ public class ArticleReadRepository implements ReadRepository<Article> {
         }
 
         if (request.getCategory() != null) {
+            Category requestCategory = categoryReadRepository.findByName(request.getCategory().name())
+                    .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_CATEGORY_NAME));
             result = result.and(ARTICLE.CATEGORY_ID.eq(requestCategory.getId()));
         }
 

--- a/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
+++ b/src/main/java/com/chatcode/repository/article/ArticleReadRepository.java
@@ -1,5 +1,6 @@
 package com.chatcode.repository.article;
 
+import static com.chatcode.handler.exception.ExceptionCode.NOT_FOUND_CATEGORY_NAME;
 import static com.chatcode.jooq.tables.Article.ARTICLE;
 import static com.chatcode.jooq.tables.Avatar.AVATAR;
 import static com.chatcode.jooq.tables.Content.CONTENT;
@@ -7,8 +8,11 @@ import static org.jooq.impl.DSL.noCondition;
 
 import com.chatcode.domain.article.ArticleVo;
 import com.chatcode.domain.entity.Article;
+import com.chatcode.domain.entity.Category;
 import com.chatcode.dto.article.ArticleRetrieveServiceDto;
+import com.chatcode.handler.exception.common.ResourceNotFoundException;
 import com.chatcode.repository.ReadRepository;
+import com.chatcode.repository.category.CategoryReadRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
@@ -23,6 +27,7 @@ import org.springframework.stereotype.Repository;
 public class ArticleReadRepository implements ReadRepository<Article> {
 
     private final DSLContext dsl;
+    private final CategoryReadRepository categoryReadRepository;
 
     @PersistenceContext
     private EntityManager em;
@@ -87,6 +92,10 @@ public class ArticleReadRepository implements ReadRepository<Article> {
     }
 
     public Condition condition(ArticleRetrieveServiceDto request) {
+
+        Category requestCategory = categoryReadRepository.findByName(request.getCategory().name())
+                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_CATEGORY_NAME));
+
         Condition result = noCondition();
 
         if (request.getSearch() != null) {
@@ -98,8 +107,7 @@ public class ArticleReadRepository implements ReadRepository<Article> {
         }
 
         if (request.getCategory() != null) {
-            // TODO: Fix this (request.getCategory().name() 가 category 이름이라면? 어떻게 비교?)
-//            result = result.and(ARTICLE.CATEGORY_ID.eq(request.getCategory().name()));
+            result = result.and(ARTICLE.CATEGORY_ID.eq(requestCategory.getId()));
         }
 
         return result;

--- a/src/main/java/com/chatcode/repository/article/ArticleRepository.java
+++ b/src/main/java/com/chatcode/repository/article/ArticleRepository.java
@@ -38,7 +38,7 @@ public class ArticleRepository {
                 .set(ARTICLE.NOTE_COUNT, 0)
                 .set(ARTICLE.SCRAP_COUNT, 0)
                 .set(ARTICLE.VIEW_COUNT, 0)
-                .set(ARTICLE.CATEGORY_ID, UUID.randomUUID().toString())
+                .set(ARTICLE.CATEGORY_ID, articleDTO.getCategoryId())
                 .set(ARTICLE.VERSION, 1L)
                 .set(ARTICLE.LIKE_COUNT, 0)
                 .set(ARTICLE.DISLIKE_COUNT, 0)
@@ -74,6 +74,7 @@ public class ArticleRepository {
         dslContext.update(ARTICLE)
                 .set(ARTICLE.TITLE, updateDTO.getTitle())
                 .set(ARTICLE.TAG_STRING, String.join(tagSplit, updateDTO.getTags()))
+                .set(ARTICLE.CATEGORY_ID, updateDTO.getCategoryId())
                 .where(ARTICLE.ID.eq(articleId))
                 .execute();
     }

--- a/src/main/java/com/chatcode/repository/category/CategoryReadRepository.java
+++ b/src/main/java/com/chatcode/repository/category/CategoryReadRepository.java
@@ -30,7 +30,7 @@ public class CategoryReadRepository implements ReadRepository<Category> {
     }
 
     public Optional<Category> findByName(String name) {
-        List<Category> categories = nativeQuery(em, dsl.select().from(CATEGORY).where(CATEGORY.NAME.eq(name)),
+        List<Category> categories = nativeQuery(em, dsl.select().from(CATEGORY).where(CATEGORY.NAME.equalIgnoreCase(name)),
                 Category.class);
         return categories.isEmpty() ? Optional.empty() : Optional.of(categories.get(0));
     }

--- a/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/Article.java
+++ b/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/Article.java
@@ -150,7 +150,7 @@ public class Article extends TableImpl<ArticleRecord> {
     /**
      * The column <code>article.category_id</code>.
      */
-    public final TableField<ArticleRecord, String> CATEGORY_ID = createField(DSL.name("category_id"), SQLDataType.VARCHAR(255).nullable(false), this, "");
+    public final TableField<ArticleRecord, Long> CATEGORY_ID = createField(DSL.name("category_id"), SQLDataType.BIGINT, this, "");
 
     private Article(Name alias, Table<ArticleRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);

--- a/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/pojos/Article.java
+++ b/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/pojos/Article.java
@@ -34,7 +34,7 @@ public class Article implements Serializable {
     private final Integer viewCount;
     private final Integer likeCount;
     private final Integer dislikeCount;
-    private final String categoryId;
+    private final Long categoryId;
 
     public Article(Article value) {
         this.id = value.id;
@@ -77,7 +77,7 @@ public class Article implements Serializable {
         Integer viewCount,
         Integer likeCount,
         Integer dislikeCount,
-        String categoryId
+        Long categoryId
     ) {
         this.id = id;
         this.version = version;
@@ -229,7 +229,7 @@ public class Article implements Serializable {
     /**
      * Getter for <code>article.category_id</code>.
      */
-    public String getCategoryId() {
+    public Long getCategoryId() {
         return this.categoryId;
     }
 

--- a/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/records/ArticleRecord.java
+++ b/src/main/java/jooq/chatcode/com/chatcode/jooq/tables/records/ArticleRecord.java
@@ -293,7 +293,7 @@ public class ArticleRecord extends UpdatableRecordImpl<ArticleRecord> {
     /**
      * Setter for <code>article.category_id</code>.
      */
-    public ArticleRecord setCategoryId(String value) {
+    public ArticleRecord setCategoryId(Long value) {
         set(18, value);
         return this;
     }
@@ -301,8 +301,8 @@ public class ArticleRecord extends UpdatableRecordImpl<ArticleRecord> {
     /**
      * Getter for <code>article.category_id</code>.
      */
-    public String getCategoryId() {
-        return (String) get(18);
+    public Long getCategoryId() {
+        return (Long) get(18);
     }
 
     // -------------------------------------------------------------------------
@@ -328,7 +328,7 @@ public class ArticleRecord extends UpdatableRecordImpl<ArticleRecord> {
     /**
      * Create a detached, initialised ArticleRecord
      */
-    public ArticleRecord(Long id, Long version, Long authorId, Boolean completed, Long contentId, String createIp, LocalDateTime dateCreated, Boolean enabled, Long lastEditorId, LocalDateTime lastUpdated, Integer noteCount, Integer scrapCount, Long selectedNoteId, String tagString, String title, Integer viewCount, Integer likeCount, Integer dislikeCount, String categoryId) {
+    public ArticleRecord(Long id, Long version, Long authorId, Boolean completed, Long contentId, String createIp, LocalDateTime dateCreated, Boolean enabled, Long lastEditorId, LocalDateTime lastUpdated, Integer noteCount, Integer scrapCount, Long selectedNoteId, String tagString, String title, Integer viewCount, Integer likeCount, Integer dislikeCount, Long categoryId) {
         super(Article.ARTICLE);
 
         setId(id);


### PR DESCRIPTION
## 🚀 Related Issues
> ref #68 
## 🛠️ Summary
> 기존 코드 중 article 등록 및 수정에서, category를 같이 등록하는 기능이 누락되어 해당 부분 개발했습니다.
## 💬 Review Requirements
> <img width="1552" alt="image" src="https://github.com/ChatCode9/ChatCode-backend/assets/47983023/ffab73e1-734a-4e3b-918d-6ffb34f502c5">
> Category ID가 Long인데, 기존 Article entity 코드를 보니 String으로 되어 있더라구요 (아마 category_old의 primary key를 보시고 String으로 하신것 같아요). 
>
>그리고 createArticle할때는 `UUID.randomUUID().toString()`으로 임의 값을 넣었구요.
>
>그래서 DB와 Article entity의 primary key를 Category entity에 맞게 Long으로 바꿔 수정 완료하긴 했으나, 문제는 ArticleReadRepository 파트에서 condition 검색을 할 때, type 충돌이 발생해요. => 이 부분 제가 바로 수정하려고 건들려고 했는데, 현재 로직 자체가 CategoryType의 이름과 Long(category_id)를 비교하는 상황이라, 민제님과 상의 후에 수정하는 것이 좋을 것 같아 일단 PR 올립니다.
